### PR TITLE
Fix TrainState field access and bump version to 0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GraphNetCore"
 uuid = "7809f980-de1b-4f9a-8451-85f041491431"
 authors = ["Julian Trommer <julian.trommer@uni-a.de>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/graph_network.jl
+++ b/src/graph_network.jl
@@ -120,7 +120,8 @@ Calculates the loss of the network based on the given loss function.
 """
 function loss(gn::GraphNetwork, graph::FeatureGraph, target::AbstractArray{Float32, 2},
         mask::AbstractArray{T, 1}, loss_function) where {T <: Integer}
-    output, _ = gn.train_state.model(graph, gn.train_state.ps, gn.train_state.st)
+    output, _ = gn.train_state.model(
+        graph, gn.train_state.parameters, gn.train_state.states)
 
     error = loss_function(target, output)
 
@@ -279,7 +280,7 @@ function load(quantities, dims, e_norms::Union{NormaliserOffline, NormaliserOnli
         st = st |> device
 
         train_state = Lux.Training.TrainState(model, ps, st, opt)
-        @set! train_state.opt_state = opt_state
+        @set! train_state.optimizer_state = opt_state
 
         gn = GraphNetwork(train_state, en, nn, on)
 


### PR DESCRIPTION
Access the `Lux.Training.TrainState` fields by their real names (`parameters`, `states`, `optimizer_state`) instead of the non-existent `ps`, `st`, `opt_state`, which would error at runtime. These field names are stable across the supported Lux range (>= 1.13).